### PR TITLE
Exclude comicvine id from metadata

### DIFF
--- a/CreateXML.py
+++ b/CreateXML.py
@@ -195,11 +195,6 @@ class ComicInfoXMLGenerator:
             web_elem = ET.SubElement(root, 'Web')
             web_elem.text = comicvine_metadata['site_detail_url']
         
-        # ComicVine ID for reference (custom field, but useful)
-        if comicvine_metadata.get('id'):
-            comicvine_id_elem = ET.SubElement(root, 'ComicVineID')
-            comicvine_id_elem.text = str(comicvine_metadata['id'])
-        
         # Format the XML with proper indentation
         rough_string = ET.tostring(root, 'unicode')
         reparsed = minidom.parseString(rough_string)


### PR DESCRIPTION
Remove ComicVineID from metadata generation to comply with the user's request to only include the ComicVine link.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4c5b018-cbea-4cb5-8be5-ba29a5ec869a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4c5b018-cbea-4cb5-8be5-ba29a5ec869a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

